### PR TITLE
Always call request.send()

### DIFF
--- a/owl/lib/util/http/webapp.dart
+++ b/owl/lib/util/http/webapp.dart
@@ -24,8 +24,8 @@ Future<HttpRequest> callHttpServer(String method, String path,
   request.onError.first.then((event) {
     if (!c.isCompleted) c.completeError(event);
   });
-  if (body != null) {
-    request.send(body);
-  }
+
+  request.send(body);
+
   return c.future;
 }


### PR DESCRIPTION
The request will never be actually invoked, if you don't call `send(...)` on it - `body` can be null :)