### PR TITLE
Support annotated getters and setters for JSON generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ contributors if you need migration path for early versions.
 ## Links
 
 - [source code][source]
-- contributors: [Agilord][agilord]
+- contributors:
+    - [Agilord][agilord]
+    - [Chance Snow][chances]
 
 [source]: https://github.com/agilord/owl
 [agilord]: https://www.agilord.com/
+[chances]: https://github.com/chances

--- a/owl_codegen/README.md
+++ b/owl_codegen/README.md
@@ -13,7 +13,10 @@ contributors if you need migration path for early versions.
 ## Links
 
 - [source code][source]
-- contributors: [Agilord][agilord]
+- contributors:
+    - [Agilord][agilord]
+    - [Chance Snow][chances]
 
 [source]: https://github.com/agilord/owl
 [agilord]: https://www.agilord.com/
+[chances]: https://github.com/chances

--- a/owl_codegen/lib/json_generator.dart
+++ b/owl_codegen/lib/json_generator.dart
@@ -124,14 +124,7 @@ class _Field {
   _Field.fromElement(FieldElement elem) {
     fieldName = elem.name;
     keyName = elem.name;
-    bool isGetterSetter = elem.getter != null && elem.setter != null;
-    final jsonField = isGetterSetter
-      // Try to get the annotation from the gettor or setter
-      ? getAnnotation(elem.getter, JsonField) == null
-        ? getAnnotation(elem.setter, JsonField)
-        : getAnnotation(elem.getter, JsonField)
-      // Otherwise get the annotation from the plain field
-      : getAnnotation(elem, JsonField);
+    final jsonField = getJsonFieldAnnotation(elem);
 
     final String fieldType = elem.type.toString();
     if (fieldType.startsWith('List<') && fieldType.endsWith('>')) {

--- a/owl_codegen/lib/json_generator.dart
+++ b/owl_codegen/lib/json_generator.dart
@@ -124,7 +124,14 @@ class _Field {
   _Field.fromElement(FieldElement elem) {
     fieldName = elem.name;
     keyName = elem.name;
-    final jsonField = getAnnotation(elem, JsonField);
+    bool isGetterSetter = elem.getter != null && elem.setter != null;
+    final jsonField = isGetterSetter
+      // Try to get the annotation from the gettor or setter
+      ? getAnnotation(elem.getter, JsonField) == null
+        ? getAnnotation(elem.setter, JsonField)
+        : getAnnotation(elem.getter, JsonField)
+      // Otherwise get the annotation from the plain field
+      : getAnnotation(elem, JsonField);
 
     final String fieldType = elem.type.toString();
     if (fieldType.startsWith('List<') && fieldType.endsWith('>')) {

--- a/owl_codegen/lib/utils.dart
+++ b/owl_codegen/lib/utils.dart
@@ -4,6 +4,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart' show BuildStep;
+import 'package:owl/annotation/json.dart';
 import 'package:source_gen/source_gen.dart';
 
 const _owlVersion = '0.2.2';
@@ -40,6 +41,26 @@ List<ClassElement> listClasses(LibraryElement library, Type annotation) =>
         .fold(new List<ClassElement>(), (l1, l2) => l1..addAll(l2))
         .where((type) => hasAnnotation(type, annotation))
         .toList();
+
+///
+DartObject getJsonFieldAnnotation(FieldElement element) {
+  DartObject jsonField;
+
+  // Try to get the annotation from the getter or setter
+  bool isGetterSetter = element.getter != null && element.setter != null;
+  if (isGetterSetter && hasAnnotation(element.getter, JsonField)) {
+    jsonField = getAnnotation(element.getter, JsonField);
+  } else if (isGetterSetter && hasAnnotation(element.setter, JsonField)) {
+    jsonField = getAnnotation(element.setter, JsonField);
+  }
+
+  // Otherwise get the annotation from the plain field
+  if (jsonField == null) {
+    jsonField = getAnnotation(element, JsonField);
+  }
+
+  return jsonField;
+}
 
 /// Creates library-level import block.
 String generateImportBlock(BuildStep buildStep,

--- a/owl_example/README.md
+++ b/owl_example/README.md
@@ -14,7 +14,10 @@ To run the code generator, execute the following command:
 ## Links
 
 - [source code][source]
-- contributors: [Agilord][agilord]
+- contributors:
+    - [Agilord][agilord]
+    - [Chance Snow][chances]
 
 [source]: https://github.com/agilord/owl
 [agilord]: https://www.agilord.com/
+[chances]: https://github.com/chances

--- a/owl_example/lib/json_example.dart
+++ b/owl_example/lib/json_example.dart
@@ -56,6 +56,17 @@ class ChildClass {
   ///
   @JsonField(native: true)
   Map map;
+
+  @Transient()
+  Map _virtualField;
+
+  ///
+  @JsonField(native: true)
+  Map get virtualNativeField => _virtualField;
+
+  ///
+  @JsonField(native: true)
+  set virtualNativeField(Map value) => _virtualField = value;
 }
 
 ///

--- a/owl_example/lib/json_example.dart
+++ b/owl_example/lib/json_example.dart
@@ -65,7 +65,7 @@ class ChildClass {
   Map get virtualNativeField => _virtualField;
 
   ///
-  @JsonField(native: true)
+  // It is enough to annotate either the getter or setter.
   set virtualNativeField(Map value) => _virtualField = value;
 }
 

--- a/owl_example/lib/json_example.json.g.dart
+++ b/owl_example/lib/json_example.json.g.dart
@@ -83,7 +83,8 @@ abstract class ChildClassMapper {
           ..put('id', object.id)
           ..put('left', ChildClassMapper.map(object.left))
           ..put('right', ChildClassMapper.map(object.right))
-          ..put('map', object.map))
+          ..put('map', object.map)
+          ..put('virtualNativeField', object.virtualNativeField))
         .toMap();
   }
 
@@ -95,6 +96,7 @@ abstract class ChildClassMapper {
     object.left = ChildClassMapper.parse(map['left']);
     object.right = ChildClassMapper.parse(map['right']);
     object.map = map['map'];
+    object.virtualNativeField = map['virtualNativeField'];
     return object;
   }
 

--- a/owl_example/test/json_test.dart
+++ b/owl_example/test/json_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('Map tests', () {
     final String exampleJson = '{"intList":[4,5,6],'
         '"dateTimeList":["2011-10-09T08:07:00.000Z"],'
-        '"children":[{"id":"2", "virtualNativeField":{"key":"value"}}]}';
+        '"children":[{"id":"2","virtualNativeField":{"key":"value"}}]}';
 
     test('From object to JSON.', () {
       final Entity entity = new Entity()
@@ -37,7 +37,7 @@ void main() {
       expect(entity.dateTimeList.first.hour, 8);
       expect(entity.dateTimeList.first.minute, 7);
       expect(entity.children.first.id, '2');
-      expect(entity.children.virtualNativeField['key'], 'value');
+      expect(entity.children.first.virtualNativeField['key'], 'value');
     });
   });
 }

--- a/owl_example/test/json_test.dart
+++ b/owl_example/test/json_test.dart
@@ -10,7 +10,7 @@ void main() {
   group('Map tests', () {
     final String exampleJson = '{"intList":[4,5,6],'
         '"dateTimeList":["2011-10-09T08:07:00.000Z"],'
-        '"children":[{"id":"2"}]}';
+        '"children":[{"id":"2", "virtualNativeField":{"key":"value"}}]}';
 
     test('From object to JSON.', () {
       final Entity entity = new Entity()
@@ -20,6 +20,7 @@ void main() {
           new ChildClass()
             ..transientField = 3
             ..id = '2'
+            ..virtualNativeField = {'key': 'value'}
         ];
       final String json = EntityMapper.toJson(entity);
       expect(json, exampleJson);
@@ -36,6 +37,7 @@ void main() {
       expect(entity.dateTimeList.first.hour, 8);
       expect(entity.dateTimeList.first.minute, 7);
       expect(entity.children.first.id, '2');
+      expect(entity.children.virtualNativeField['key'], 'value');
     });
   });
 }


### PR DESCRIPTION
The JSON generator treated my getter/setter fields as ones where a `*Mapper` exists which is not the case. The field parser is not reading getter/setter annotations correctly.

This PR fixes that.